### PR TITLE
Implement cubic rectilinear method

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ as can the RAM usage.
 | multilinear::regular          | O(ndims)  | O(2^ndims * ndims)       | O(2^ndims * ndims)                      | O(2^ndims + ndims^2)                           |
 | multilinear::rectilinear      | O(ndims)  | O(2^ndims * ndims)       | O(ndims * (2^ndims + log2(gridsize)))   | O(ndims * (2^ndims + ndims + log2(gridsize)))  |
 | multicubic::regular           | O(ndims)  | O(4^ndims)               | O(4^ndims)                              | O(4^ndims)                                     |
+| multicubic::rectilinear       | O(ndims)  | O(4^ndims)               | O(4^ndims) + ndims * log2(gridsize)     | O(4^ndims) + ndims * log2(gridsize)            |
 
 # Example: Multilinear and Multicubic w/ Regular Grid
 ```rust
@@ -49,19 +50,19 @@ multilinear::regular::interpn(&dims, &starts, &steps, &z, &obs, &mut out);
 multicubic::regular::interpn(&dims, &starts, &steps, &z, false, &obs, &mut out);
 ```
 
-# Example: Multilinear w/ Rectilinear Grid
+# Example: Multilinear and Multicubic w/ Rectilinear Grid
 ```rust
-use interpn::multilinear::rectilinear;
+use interpn::{multilinear, multicubic};
 
 // Define a grid
-let x = [1.0_f64, 1.2, 2.0];
-let y = [1.0_f64, 1.3, 1.5];
+let x = [1.0_f64, 2.0, 3.0, 4.0];
+let y = [0.0_f64, 1.0, 2.0, 3.0];
 
 // Grid input for rectilinear method
 let grids = &[&x[..], &y[..]];
 
 // Values at grid points
-let z = [2.0; 9];
+let z = [2.0; 16];
 
 // Points to interpolate/extrapolate
 let xobs = [0.0_f64, 5.0];
@@ -72,11 +73,13 @@ let obs = [&xobs[..], &yobs[..]];
 let mut out = [0.0; 2];
 
 // Do interpolation
-rectilinear::interpn(grids, &z, &obs, &mut out).unwrap();
+multilinear::rectilinear::interpn(grids, &z, &obs, &mut out).unwrap();
+multicubic::rectilinear::interpn(grids, &z, false, &obs, &mut out).unwrap();
 ```
 
 # Development Roadmap
-* Recursive multilinear method (for better extrapolation speed and timing determinism)
+* Recursive multilinear methods (for better extrapolation speed and timing determinism)
+* Methods for unstructured triangular and tetrahedral meshes
 
 # License
 Licensed under either of

--- a/interpn/Cargo.toml
+++ b/interpn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interpn"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 authors = ["James Logan <jlogan03@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/interpn/README.md
+++ b/interpn/README.md
@@ -16,6 +16,7 @@ as can the RAM usage.
 | multilinear::regular          | O(ndims)  | O(2^ndims * ndims)       | O(2^ndims * ndims)                      | O(2^ndims + ndims^2)                           |
 | multilinear::rectilinear      | O(ndims)  | O(2^ndims * ndims)       | O(ndims * (2^ndims + log2(gridsize)))   | O(ndims * (2^ndims + ndims + log2(gridsize)))  |
 | multicubic::regular           | O(ndims)  | O(4^ndims)               | O(4^ndims)                              | O(4^ndims)                                     |
+| multicubic::rectilinear       | O(ndims)  | O(4^ndims)               | O(4^ndims) + ndims * log2(gridsize)     | O(4^ndims) + ndims * log2(gridsize)            |
 
 # Example: Multilinear and Multicubic w/ Regular Grid
 ```rust
@@ -49,19 +50,19 @@ multilinear::regular::interpn(&dims, &starts, &steps, &z, &obs, &mut out);
 multicubic::regular::interpn(&dims, &starts, &steps, &z, false, &obs, &mut out);
 ```
 
-# Example: Multilinear w/ Rectilinear Grid
+# Example: Multilinear and Multicubic w/ Rectilinear Grid
 ```rust
-use interpn::multilinear::rectilinear;
+use interpn::{multilinear, multicubic};
 
 // Define a grid
-let x = [1.0_f64, 1.2, 2.0];
-let y = [1.0_f64, 1.3, 1.5];
+let x = [1.0_f64, 2.0, 3.0, 4.0];
+let y = [0.0_f64, 1.0, 2.0, 3.0];
 
 // Grid input for rectilinear method
 let grids = &[&x[..], &y[..]];
 
 // Values at grid points
-let z = [2.0; 9];
+let z = [2.0; 16];
 
 // Points to interpolate/extrapolate
 let xobs = [0.0_f64, 5.0];
@@ -72,11 +73,13 @@ let obs = [&xobs[..], &yobs[..]];
 let mut out = [0.0; 2];
 
 // Do interpolation
-rectilinear::interpn(grids, &z, &obs, &mut out).unwrap();
+multilinear::rectilinear::interpn(grids, &z, &obs, &mut out).unwrap();
+multicubic::rectilinear::interpn(grids, &z, false, &obs, &mut out).unwrap();
 ```
 
 # Development Roadmap
-* Recursive multilinear method (for better extrapolation speed and timing determinism)
+* Recursive multilinear methods (for better extrapolation speed and timing determinism)
+* Methods for unstructured triangular and tetrahedral meshes
 
 # License
 Licensed under either of

--- a/interpn/src/lib.rs
+++ b/interpn/src/lib.rs
@@ -84,7 +84,7 @@ pub mod multilinear;
 pub use multilinear::{MultilinearRectilinear, MultilinearRegular};
 
 pub mod multicubic;
-pub use multicubic::MulticubicRegular;
+pub use multicubic::{MulticubicRegular, MulticubicRectilinear};
 
 #[cfg(feature = "std")]
 pub mod utils;

--- a/interpn/src/lib.rs
+++ b/interpn/src/lib.rs
@@ -15,6 +15,7 @@
 //! | multilinear::regular          | O(ndims)  | O(2^ndims * ndims)       | O(2^ndims * ndims)                      | O(2^ndims + ndims^2)                           |
 //! | multilinear::rectilinear      | O(ndims)  | O(2^ndims * ndims)       | O(ndims * (2^ndims + log2(gridsize)))   | O(ndims * (2^ndims + ndims + log2(gridsize)))  |
 //! | multicubic::regular           | O(ndims)  | O(4^ndims)               | O(4^ndims)                              | O(4^ndims)                                     |
+//! | multicubic::rectilinear       | O(ndims)  | O(4^ndims)               | O(4^ndims) + ndims * log2(gridsize)     | O(4^ndims) + ndims * log2(gridsize)            |
 //!
 //! # Example: Multilinear and Multicubic w/ Regular Grid
 //! ```rust
@@ -48,19 +49,19 @@
 //! multicubic::regular::interpn(&dims, &starts, &steps, &z, false, &obs, &mut out);
 //! ```
 //!
-//! # Example: Multilinear w/ Rectilinear Grid
+//! # Example: Multilinear and Multicubic w/ Rectilinear Grid
 //! ```rust
-//! use interpn::multilinear::rectilinear;
+//! use interpn::{multilinear, multicubic};
 //!
 //! // Define a grid
-//! let x = [1.0_f64, 1.2, 2.0];
-//! let y = [1.0_f64, 1.3, 1.5];
+//! let x = [1.0_f64, 2.0, 3.0, 4.0];
+//! let y = [0.0_f64, 1.0, 2.0, 3.0];
 //!
 //! // Grid input for rectilinear method
 //! let grids = &[&x[..], &y[..]];
 //!
 //! // Values at grid points
-//! let z = [2.0; 9];
+//! let z = [2.0; 16];
 //!
 //! // Points to interpolate/extrapolate
 //! let xobs = [0.0_f64, 5.0];
@@ -71,7 +72,8 @@
 //! let mut out = [0.0; 2];
 //!
 //! // Do interpolation
-//! rectilinear::interpn(grids, &z, &obs, &mut out);
+//! multilinear::rectilinear::interpn(grids, &z, &obs, &mut out).unwrap();
+//! multicubic::rectilinear::interpn(grids, &z, false, &obs, &mut out).unwrap();
 //! ```
 //!
 //! # Development Roadmap

--- a/interpn/src/lib.rs
+++ b/interpn/src/lib.rs
@@ -77,7 +77,8 @@
 //! ```
 //!
 //! # Development Roadmap
-//! * Recursive
+//! * Recursive multilinear methods (for better extrapolation speed and timing determinism)
+//! * Methods for unstructured triangular and tetrahedral meshes
 #![cfg_attr(not(feature = "std"), no_std)]
 // These "needless" range loops are a significant speedup
 #![allow(clippy::needless_range_loop)]

--- a/interpn/src/lib.rs
+++ b/interpn/src/lib.rs
@@ -84,7 +84,7 @@ pub mod multilinear;
 pub use multilinear::{MultilinearRectilinear, MultilinearRegular};
 
 pub mod multicubic;
-pub use multicubic::{MulticubicRegular, MulticubicRectilinear};
+pub use multicubic::{MulticubicRectilinear, MulticubicRegular};
 
 #[cfg(feature = "std")]
 pub mod utils;

--- a/interpn/src/multicubic/mod.rs
+++ b/interpn/src/multicubic/mod.rs
@@ -44,8 +44,8 @@
 //!     on the correctness and continuity of the first derivative,
 //!     but can tolerate some discontinuity in the second derivative
 
-pub mod regular;
 pub mod rectilinear;
+pub mod regular;
 
-pub use regular::MulticubicRegular;
 pub use rectilinear::MulticubicRectilinear;
+pub use regular::MulticubicRegular;

--- a/interpn/src/multicubic/mod.rs
+++ b/interpn/src/multicubic/mod.rs
@@ -45,4 +45,7 @@
 //!     but can tolerate some discontinuity in the second derivative
 
 pub mod regular;
+pub mod rectilinear;
+
 pub use regular::MulticubicRegular;
+pub use rectilinear::MulticubicRectilinear;

--- a/interpn/src/multicubic/rectilinear.rs
+++ b/interpn/src/multicubic/rectilinear.rs
@@ -1,4 +1,4 @@
-//! An arbitrary-dimensional multicubic interpolator / extrapolator on a regular grid.
+//! An arbitrary-dimensional multicubic interpolator / extrapolator on a rectilinear grid.
 //!
 //! On interior points, a hermite spline is used, with the derivative at each
 //! grid point matched to a second-order central difference. This allows the
@@ -43,7 +43,7 @@
 //!   when evaluated at off-grid points.
 //!
 //! ```rust
-//! use interpn::multicubic::regular::interpn;
+//! use interpn::multicubic::rectilinear;
 //!
 //! // Define a grid
 //! let x = [1.0_f64, 2.0, 3.0, 4.0];
@@ -52,15 +52,10 @@
 //! // Grid input for rectilinear method
 //! let grids = &[&x[..], &y[..]];
 //!
-//! // Grid input for regular grid method
-//! let dims = [x.len(), y.len()];
-//! let starts = [x[0], y[0]];
-//! let steps = [x[1] - x[0], y[1] - y[0]];
-//!
 //! // Values at grid points
 //! let z = [2.0; 16];
 //!
-//! // Observation points to interpolate/extrapolate
+//! // Points to interpolate/extrapolate
 //! let xobs = [0.0_f64, 5.0];
 //! let yobs = [-1.0, 3.0];
 //! let obs = [&xobs[..], &yobs[..]];
@@ -70,8 +65,12 @@
 //!
 //! // Do interpolation
 //! let linearize_extrapolation = false;
-//! interpn(&dims, &starts, &steps, &z, linearize_extrapolation, &obs, &mut out).unwrap();
+//! rectilinear::interpn(grids, &z, linearize_extrapolation, &obs, &mut out).unwrap();
 //! ```
+//! 
+//! References
+//! * A. E. P. Veldman and K. Rinzema, “Playing with nonuniform grids”.
+//!   https://pure.rug.nl/ws/portalfiles/portal/3332271/1992JEngMathVeldman.pdf
 use num_traits::Float;
 
 #[derive(Clone, Copy, PartialEq)]

--- a/interpn/src/multicubic/rectilinear.rs
+++ b/interpn/src/multicubic/rectilinear.rs
@@ -585,54 +585,6 @@ mod test {
     use crate::testing::*;
     use crate::utils::*;
 
-    /// Iterate from 1 to 6 dimensions, making a minimum-sized grid for each one
-    /// to traverse every combination of interpolating or extrapolating high or low on each dimension.
-    /// Each test evaluates at 5^ndims locations, largely extrapolated in corner regions, so it
-    /// rapidly becomes prohibitively slow above ndims=6.
-    // #[test]
-    // fn test_interp_extrap_1d_to_6d_linear() {
-    //     for ndims in 1..6 {
-    //         println!("Testing in {ndims} dims");
-    //         // Interp grid
-    //         let dims: Vec<usize> = vec![4; ndims];
-    //         let xs: Vec<Vec<f64>> = (0..ndims)
-    //             .map(|i| linspace(-5.0 * (i as f64), 5.0 * ((i + 1) as f64), dims[i]))
-    //             .collect();
-    //         let grid = meshgrid((0..ndims).map(|i| &xs[i]).collect());
-    //         let u: Vec<f64> = grid.iter().map(|x| x.iter().sum()).collect(); // sum is linear in every direction, good for testing
-    //         let starts: Vec<f64> = xs.iter().map(|x| x[0]).collect();
-    //         let steps: Vec<f64> = xs.iter().map(|x| x[1] - x[0]).collect();
-
-    //         // Observation points
-    //         let xobs: Vec<Vec<f64>> = (0..ndims)
-    //             .map(|i| linspace(-7.0 * (i as f64), 7.0 * ((i + 1) as f64), 5))
-    //             .collect();
-    //         let gridobs = meshgrid((0..ndims).map(|i| &xobs[i]).collect());
-    //         let gridobs_t: Vec<Vec<f64>> = (0..ndims)
-    //             .map(|i| gridobs.iter().map(|x| x[i]).collect())
-    //             .collect(); // transpose
-    //         let xobsslice: Vec<&[f64]> = gridobs_t.iter().map(|x| &x[..]).collect();
-    //         let uobs: Vec<f64> = gridobs.iter().map(|x| x.iter().sum()).collect(); // expected output at observation points
-    //         let mut out = vec![0.0; uobs.len()];
-
-    //         // Evaluate with spline extrapolation, which should collapse to linear
-    //         interpn(&dims, &starts, &steps, &u, false, &xobsslice, &mut out[..]).unwrap();
-
-    //         // Check that interpolated values match expectation,
-    //         // using an absolute difference because some points are very close to or exactly at zero,
-    //         // and do not do well under a check on relative difference.
-    //         (0..uobs.len()).for_each(|i| assert!((out[i] - uobs[i]).abs() < 1e-12));
-
-    //         // Evaluate with linear extrapolation
-    //         interpn(&dims, &starts, &steps, &u, true, &xobsslice, &mut out[..]).unwrap();
-
-    //         // Check that interpolated values match expectation,
-    //         // using an absolute difference because some points are very close to or exactly at zero,
-    //         // and do not do well under a check on relative difference.
-    //         (0..uobs.len()).for_each(|i| assert!((out[i] - uobs[i]).abs() < 1e-12));
-    //     }
-    // }
-
     /// Iterate from 1 to 8 dimensions, making a minimum-sized grid for each one
     /// to traverse every combination of interpolating or extrapolating high or low on each dimension.
     /// Each test evaluates at 5^ndims locations, largely extrapolated in corner regions, so it
@@ -756,7 +708,7 @@ mod test {
     #[test]
     fn test_interp_1d_to_3d_sine() {
         let mut rng = rng_fixed_seed();
-        
+
         for ndims in 1..3 {
             println!("Testing in {ndims} dims");
             // Interp grid

--- a/interpn/src/multicubic/rectilinear.rs
+++ b/interpn/src/multicubic/rectilinear.rs
@@ -67,7 +67,7 @@
 //! let linearize_extrapolation = false;
 //! rectilinear::interpn(grids, &z, linearize_extrapolation, &obs, &mut out).unwrap();
 //! ```
-//! 
+//!
 //! References
 //! * A. E. P. Veldman and K. Rinzema, “Playing with nonuniform grids”.
 //!   https://pure.rug.nl/ws/portalfiles/portal/3332271/1992JEngMathVeldman.pdf

--- a/interpn/src/multicubic/rectilinear.rs
+++ b/interpn/src/multicubic/rectilinear.rs
@@ -681,7 +681,7 @@ mod test {
             // Check that interpolated values match expectation,
             // using an absolute difference because some points are very close to or exactly at zero,
             // and do not do well under a check on relative difference.
-            (0..uobs.len()).for_each(|i| assert!((out[i] - uobs[i]).abs() < 1e-12));
+            (0..uobs.len()).for_each(|i| assert!((out[i] - uobs[i]).abs() < 1e-10));
         }
     }
 

--- a/interpn/src/multicubic/regular.rs
+++ b/interpn/src/multicubic/regular.rs
@@ -593,7 +593,7 @@ mod test {
 
             // Observation points
             let xobs: Vec<Vec<f64>> = (0..ndims)
-                .map(|i| linspace(-7.0 * (i as f64), 7.0 * ((i + 1) as f64), 5))
+                .map(|i| linspace(-7.0 * (i as f64), 7.0 * ((i + 1) as f64), dims[i] + 2))
                 .collect();
             let gridobs = meshgrid((0..ndims).map(|i| &xobs[i]).collect());
             let gridobs_t: Vec<Vec<f64>> = (0..ndims)
@@ -647,7 +647,7 @@ mod test {
 
             // Observation points
             let xobs: Vec<Vec<f64>> = (0..ndims)
-                .map(|i| linspace(-7.0 * (i as f64), 7.0 * ((i + 1) as f64), 5))
+                .map(|i| linspace(-7.0 * (i as f64), 7.0 * ((i + 1) as f64), dims[i] + 2))
                 .collect();
             let gridobs = meshgrid((0..ndims).map(|i| &xobs[i]).collect());
             let gridobs_t: Vec<Vec<f64>> = (0..ndims)
@@ -703,7 +703,7 @@ mod test {
 
             // Observation points
             let xobs: Vec<Vec<f64>> = (0..ndims)
-                .map(|i| linspace(-5.0 * (i as f64), 5.0 * ((i + 1) as f64), dims[i] + 1))
+                .map(|i| linspace(-5.0 * (i as f64), 5.0 * ((i + 1) as f64), dims[i] + 2))
                 .collect();
             let gridobs = meshgrid((0..ndims).map(|i| &xobs[i]).collect());
             let gridobs_t: Vec<Vec<f64>> = (0..ndims)
@@ -731,7 +731,7 @@ mod test {
 
             (0..uobs.len()).for_each(|i| {
                 let err = out[i] - uobs[i];
-                println!("{err}");
+                // println!("{err}");
                 assert!(err.abs() < tol);
             });
         }

--- a/interpn/src/multicubic/regular.rs
+++ b/interpn/src/multicubic/regular.rs
@@ -317,7 +317,7 @@ impl<'a, T: Float, const MAXDIMS: usize> MulticubicRegular<'a, T, MAXDIMS> {
         let iloc = <isize as NumCast>::from(floc).ok_or("Unrepresentable coordinate value")? - 1;
 
         let n = self.dims[dim] as isize; // Number of grid points on this dimension
-        let dimmax = (n - 4).max(0); // maximum index for lower corner
+        let dimmax = n.saturating_sub(4).max(0); // maximum index for lower corner
         let loc: usize = iloc.max(0).min(dimmax) as usize; // unsigned integer loc clipped to interior
 
         // Observation point is outside the grid on the low side

--- a/interpn/src/multilinear/rectilinear.rs
+++ b/interpn/src/multilinear/rectilinear.rs
@@ -539,7 +539,7 @@ mod test {
                     // Make a linear grid and add noise
                     let mut x = linspace(-5.0 * (i as f64), 5.0 * ((i + 1) as f64), dims[i]);
                     let dx = randn::<f64>(&mut rng, x.len());
-                    (0..x.len()).for_each(|i| x[i] += (dx[i] - 0.5) / 1e3);
+                    (0..x.len()).for_each(|i| x[i] += (dx[i] - 0.5) / 10.0);
                     (0..x.len() - 1).for_each(|i| assert!(x[i + 1] > x[i]));
                     x
                 })

--- a/interpn/src/multilinear/rectilinear.rs
+++ b/interpn/src/multilinear/rectilinear.rs
@@ -117,7 +117,7 @@ impl<'a, T: Float, const MAXDIMS: usize> MultilinearRectilinear<'a, T, MAXDIMS> 
         let ndims = grids.len();
         let mut dims = [1_usize; MAXDIMS];
         (0..ndims).for_each(|i| dims[i] = grids[i].len());
-        let nvals = dims[..ndims].iter().product();
+        let nvals: usize = dims[..ndims].iter().product();
         if !(vals.len() == nvals && ndims > 0 && ndims <= MAXDIMS) {
             return Err("Dimension mismatch");
         };

--- a/interpn/src/multilinear/regular.rs
+++ b/interpn/src/multilinear/regular.rs
@@ -112,7 +112,7 @@ impl<'a, T: Float, const MAXDIMS: usize> MultilinearRegular<'a, T, MAXDIMS> {
     ) -> Result<Self, &'static str> {
         // Check dimensions
         let ndims = dims.len();
-        let nvals = dims.iter().product();
+        let nvals: usize = dims.iter().product();
         if !(starts.len() == ndims && steps.len() == ndims && vals.len() == nvals && ndims > 0) {
             return Err("Dimension mismatch");
         }

--- a/test_no_std/src/main.rs
+++ b/test_no_std/src/main.rs
@@ -42,6 +42,7 @@ pub fn _start() -> ! {
     regular::interpn(&dims, &starts, &steps, &z, &obs, &mut out).unwrap();
     rectilinear::interpn(grids, &z, &obs, &mut out).unwrap();
     multicubic::regular::interpn(&dims, &starts, &steps, &z, false, &obs, &mut out).unwrap();
+    multicubic::rectilinear::interpn(grids, &z, false, &obs, &mut out).unwrap();
 
     loop {} // We don't actually run this, just compile it
 }


### PR DESCRIPTION
* Implement MulticubicRectilinear using slope constraints from central difference on nonuniform grid
* Use saturating sub in MulticubicRegular instead of relying on grid size guarantee
* Increase number of observation points in MulticubicRegular tests
* Increase grid jitter magnitude in tests for rectilinear methods from 1e-3 to 0.1