### PR TITLE
Match input dimensionality to specialized method

### DIFF
--- a/interpn/.cargo/config.toml
+++ b/interpn/.cargo/config.toml
@@ -1,0 +1,3 @@
+[target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))']
+rustflags = ["-C", "target-feature=+fma"]
+

--- a/interpn/CHANGELOG.md
+++ b/interpn/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.4.5 - 2025-03-14
+
+### Changed
+
+* Update `interpn` functions to select specialized generic version of interpolation calc based on number of dimensions in inputs
+  * ~2-6x speedup for lower-dimensional inputs
+  * Slight slowdown (~10%) for cases with one observation point, due to match statement overhead
+
 ## 0.4.4 - 2025-02-28
 
 ### Added

--- a/interpn/CHANGELOG.md
+++ b/interpn/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Update `interpn` functions to select specialized generic version of interpolation calc based on number of dimensions in inputs
   * ~2-6x speedup for lower-dimensional inputs
   * Slight slowdown (~10%) for cases with one observation point, due to match statement overhead
+* Add .cargo/config.toml with configuration to enable modern vector instructions on x86 targets
+  * Additional 20-30% speedup for regular grid methods on top of monomorphization speedups
 
 ## 0.4.4 - 2025-02-28
 

--- a/interpn/Cargo.toml
+++ b/interpn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interpn"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 authors = ["James Logan <jlogan03@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/interpn/src/multicubic/rectilinear.rs
+++ b/interpn/src/multicubic/rectilinear.rs
@@ -48,8 +48,42 @@ pub fn interpn<T: Float>(
     obs: &[&[T]],
     out: &mut [T],
 ) -> Result<(), &'static str> {
-    MulticubicRectilinear::<'_, T, 8>::new(grids, vals, linearize_extrapolation)?
-        .interp(obs, out)?;
+    // Expanding out and using the specialized version for each size
+    // gives a substantial speedup for lower dimensionalities
+    // (4-5x speedup for 1-dim compared to using MAXDIMS=8)
+    let ndims = grids.len();
+    match ndims {
+        x if x == 1 => {
+            MulticubicRectilinear::<'_, T, 1>::new(grids, vals, linearize_extrapolation)?
+                .interp(obs, out)
+        }
+        x if x == 2 => {
+            MulticubicRectilinear::<'_, T, 2>::new(grids, vals, linearize_extrapolation)?
+                .interp(obs, out)
+        }
+        x if x == 3 => {
+            MulticubicRectilinear::<'_, T, 3>::new(grids, vals, linearize_extrapolation)?
+                .interp(obs, out)
+        }
+        x if x == 4 => {
+            MulticubicRectilinear::<'_, T, 4>::new(grids, vals, linearize_extrapolation)?
+                .interp(obs, out)
+        }
+        x if x == 5 => {
+            MulticubicRectilinear::<'_, T, 5>::new(grids, vals, linearize_extrapolation)?
+                .interp(obs, out)
+        }
+        x if x == 6 => {
+            MulticubicRectilinear::<'_, T, 6>::new(grids, vals, linearize_extrapolation)?
+                .interp(obs, out)
+        }
+        x if x == 7 => {
+            MulticubicRectilinear::<'_, T, 7>::new(grids, vals, linearize_extrapolation)?
+                .interp(obs, out)
+        }
+        _ => MulticubicRectilinear::<'_, T, 8>::new(grids, vals, linearize_extrapolation)?
+            .interp(obs, out),
+    }?;
     Ok(())
 }
 

--- a/interpn/src/multicubic/rectilinear.rs
+++ b/interpn/src/multicubic/rectilinear.rs
@@ -84,6 +84,7 @@ pub fn interpn<T: Float>(
         _ => MulticubicRectilinear::<'_, T, 8>::new(grids, vals, linearize_extrapolation)?
             .interp(obs, out),
     }?;
+
     Ok(())
 }
 

--- a/interpn/src/multicubic/regular.rs
+++ b/interpn/src/multicubic/regular.rs
@@ -51,8 +51,45 @@ pub fn interpn<T: Float>(
     obs: &[&[T]],
     out: &mut [T],
 ) -> Result<(), &'static str> {
-    MulticubicRegular::<'_, T, 8>::new(dims, starts, steps, vals, linearize_extrapolation)?
-        .interp(obs, out)?;
+    // Expanding out and using the specialized version for each size
+    // gives a substantial speedup for lower dimensionalities
+    // (4-5x speedup for 1-dim compared to using MAXDIMS=8)
+    let ndims = dims.len();
+    match ndims {
+        x if x == 1 => {
+            MulticubicRegular::<'_, T, 1>::new(dims, starts, steps, vals, linearize_extrapolation)?
+                .interp(obs, out)
+        }
+        x if x == 2 => {
+            MulticubicRegular::<'_, T, 2>::new(dims, starts, steps, vals, linearize_extrapolation)?
+                .interp(obs, out)
+        }
+        x if x == 3 => {
+            MulticubicRegular::<'_, T, 3>::new(dims, starts, steps, vals, linearize_extrapolation)?
+                .interp(obs, out)
+        }
+        x if x == 4 => {
+            MulticubicRegular::<'_, T, 4>::new(dims, starts, steps, vals, linearize_extrapolation)?
+                .interp(obs, out)
+        }
+        x if x == 5 => {
+            MulticubicRegular::<'_, T, 5>::new(dims, starts, steps, vals, linearize_extrapolation)?
+                .interp(obs, out)
+        }
+        x if x == 6 => {
+            MulticubicRegular::<'_, T, 6>::new(dims, starts, steps, vals, linearize_extrapolation)?
+                .interp(obs, out)
+        }
+        x if x == 7 => {
+            MulticubicRegular::<'_, T, 7>::new(dims, starts, steps, vals, linearize_extrapolation)?
+                .interp(obs, out)
+        }
+        _ => {
+            MulticubicRegular::<'_, T, 8>::new(dims, starts, steps, vals, linearize_extrapolation)?
+                .interp(obs, out)
+        }
+    }?;
+
     Ok(())
 }
 

--- a/interpn/src/multilinear/rectilinear.rs
+++ b/interpn/src/multilinear/rectilinear.rs
@@ -45,7 +45,21 @@ pub fn interpn<T: Float>(
     obs: &[&[T]],
     out: &mut [T],
 ) -> Result<(), &'static str> {
-    MultilinearRectilinear::<'_, T, 8>::new(grids, vals)?.interp(obs, out)?;
+    // Expanding out and using the specialized version for each size
+    // gives a substantial speedup for lower dimensionalities
+    // (4-5x speedup for 1-dim compared to using MAXDIMS=8)
+    let ndims = grids.len();
+    match ndims {
+        x if x == 1 => MultilinearRectilinear::<'_, T, 1>::new(grids, vals)?.interp(obs, out),
+        x if x == 2 => MultilinearRectilinear::<'_, T, 2>::new(grids, vals)?.interp(obs, out),
+        x if x == 3 => MultilinearRectilinear::<'_, T, 3>::new(grids, vals)?.interp(obs, out),
+        x if x == 4 => MultilinearRectilinear::<'_, T, 4>::new(grids, vals)?.interp(obs, out),
+        x if x == 5 => MultilinearRectilinear::<'_, T, 5>::new(grids, vals)?.interp(obs, out),
+        x if x == 6 => MultilinearRectilinear::<'_, T, 6>::new(grids, vals)?.interp(obs, out),
+        x if x == 7 => MultilinearRectilinear::<'_, T, 7>::new(grids, vals)?.interp(obs, out),
+        _ => MultilinearRectilinear::<'_, T, 8>::new(grids, vals)?.interp(obs, out),
+    }?;
+
     Ok(())
 }
 

--- a/interpn/src/multilinear/regular.rs
+++ b/interpn/src/multilinear/regular.rs
@@ -49,7 +49,35 @@ pub fn interpn<T: Float>(
     obs: &[&[T]],
     out: &mut [T],
 ) -> Result<(), &'static str> {
-    MultilinearRegular::<'_, T, 8>::new(dims, starts, steps, vals)?.interp(obs, out)?;
+    // Expanding out and using the specialized version for each size
+    // gives a substantial speedup for lower dimensionalities
+    // (4-5x speedup for 1-dim compared to using MAXDIMS=8)
+    let ndims = dims.len();
+    match ndims {
+        x if x == 1 => {
+            MultilinearRegular::<'_, T, 1>::new(dims, starts, steps, vals)?.interp(obs, out)
+        }
+        x if x == 2 => {
+            MultilinearRegular::<'_, T, 2>::new(dims, starts, steps, vals)?.interp(obs, out)
+        }
+        x if x == 3 => {
+            MultilinearRegular::<'_, T, 3>::new(dims, starts, steps, vals)?.interp(obs, out)
+        }
+        x if x == 4 => {
+            MultilinearRegular::<'_, T, 4>::new(dims, starts, steps, vals)?.interp(obs, out)
+        }
+        x if x == 5 => {
+            MultilinearRegular::<'_, T, 5>::new(dims, starts, steps, vals)?.interp(obs, out)
+        }
+        x if x == 6 => {
+            MultilinearRegular::<'_, T, 6>::new(dims, starts, steps, vals)?.interp(obs, out)
+        }
+        x if x == 7 => {
+            MultilinearRegular::<'_, T, 7>::new(dims, starts, steps, vals)?.interp(obs, out)
+        }
+        _ => MultilinearRegular::<'_, T, 8>::new(dims, starts, steps, vals)?.interp(obs, out),
+    }?;
+
     Ok(())
 }
 


### PR DESCRIPTION
## 0.4.5 - 2025-03-14

### Changed

* Update `interpn` functions to select specialized generic version of interpolation calc based on number of dimensions in inputs
  * ~2-6x speedup for lower-dimensional inputs
  * Slight slowdown (~10%) for cases with one observation point, due to match statement overhead
* Add .cargo/config.toml with configuration to enable modern vector instructions on x86 targets
  * Additional 20-30% speedup for regular grid methods on top of monomorphization speedups