### PR TITLE
DEP: un-expose dev-only Python dependencies using PEP 735 dependency groups

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -21,14 +21,13 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         python-version: ${{ matrix.python-version }}
+        enable-cache: false
 
     - name: Install
-      run: |
-        uv venv
-        uv pip install -e .[test,bench]
+      run: uv sync --group test --group bench
       
     - name: Format
       run: uv run ruff check; uv run ruff format --check
@@ -54,14 +53,14 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         python-version: ${{ matrix.python-version }}
+        enable-cache: false
 
     - name: Install
       run: |
-        uv venv
-        uv pip install .[test,bench]
+        uv sync --no-editable --group test --group bench
         rustup component add llvm-tools-preview
 
     - name: Profile-Guided Optimization (PGO)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
 repository = "https://github.com/jlogan03/interpn"
 documentation = "https://interpn.readthedocs.io/"
 
-[project.optional-dependencies]
+[dependency-groups]
 test = [
     "pytest >= 8.4.2",
     "pytest-cov >= 7.0.0",


### PR DESCRIPTION
I figure all dependencies currently under `[optional-dependencies]` are not meant to be user facing.
