### PR TITLE
MNT: cleanup redundant ruff option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,9 +71,6 @@ include = [
 [tool.pytest.ini_options]
 addopts = "--cov=interpn --cov-report html --cov-fail-under=94"
 
-[tool.ruff]
-target-version = "py39"
-
 [tool.ruff.lint]
 select = [
     # pycodestyle


### PR DESCRIPTION
This options has been redundant for a couple years; ruff will infer it from `project.requires-python`