### PR TITLE
RFC: add explicit strict kwargs to zip calls (fix lint B905)

### DIFF
--- a/examples/nearest_comparison.py
+++ b/examples/nearest_comparison.py
@@ -78,7 +78,7 @@ if __name__ == "__main__":
     ]
 
     extent = [x_eval.min(), x_eval.max(), y_eval.min(), y_eval.max()]
-    for ax, (data, title) in zip(axes, plots):
+    for ax, (data, title) in zip(axes, plots, strict=True):
         im = ax.imshow(
             data.T,
             origin="lower",

--- a/test/test_nearest_rectilinear.py
+++ b/test/test_nearest_rectilinear.py
@@ -42,7 +42,7 @@ def test_nearest_rectilinear():
             )
 
         expected = []
-        for xi, yi in zip(obs[0], obs[1]):
+        for xi, yi in zip(obs[0], obs[1], strict=True):
             ix = _nearest_rectilinear_index(float(xi), grids[0])
             iy = _nearest_rectilinear_index(float(yi), grids[1])
             expected.append(zgrid[ix, iy])

--- a/test/test_nearest_regular.py
+++ b/test/test_nearest_regular.py
@@ -48,7 +48,7 @@ def test_nearest_regular():
             )
 
         expected = []
-        for xi, yi in zip(obs[0], obs[1]):
+        for xi, yi in zip(obs[0], obs[1], strict=True):
             ix = _nearest_regular_index(
                 float(xi), float(starts[0]), float(steps[0]), dims[0]
             )


### PR DESCRIPTION
I don't know why this didn't show up in #40, but here's the fix