### PR TITLE
Improve compile time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.9.0 2025-11-12
+
+### Added
+
+* Add `deep-unroll` feature that sets crunchy unroll depth to 256 and enables 4D unrolled cubic interpolation
+  * This improves compile times in typical use-cases
+
+### Changed
+
+* Gate 4D unrolled cubic interpolation behind `deep-unroll` feature
+* Enable `deep-unroll` feature for Python builds
+
 ## 0.8.2 2025-11-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,19 @@
 # Changelog
 
-## 0.9.0 2025-11-12
+## 0.9.0 2025-12-27
 
 ### Added
 
-* Add `deep-unroll` feature that sets crunchy unroll depth to 256 and enables 4D unrolled cubic interpolation
-  * This improves compile times in typical use-cases
+* Rust
+  * Add `deep-unroll` feature that sets crunchy unroll depth to 256 and enables 4D unrolled cubic interpolation
+    * This improves compile times in typical use-cases
 
 ### Changed
 
-* Gate 4D unrolled cubic interpolation behind `deep-unroll` feature
-* Enable `deep-unroll` feature for Python builds
+* Rust
+  * Gate 4D unrolled cubic interpolation behind `deep-unroll` feature
+  * Enable `deep-unroll` feature for Python builds
+  * Update pyo3 deps
 
 ## 0.8.2 2025-11-12
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,12 +221,12 @@ checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "interpn"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "criterion",
  "crunchy",
  "itertools 0.14.0",
- "ndarray 0.17.1",
+ "ndarray",
  "num-traits",
  "numpy",
  "pyo3",
@@ -312,21 +312,6 @@ dependencies = [
 
 [[package]]
 name = "ndarray"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
-dependencies = [
- "matrixmultiply",
- "num-complex",
- "num-integer",
- "num-traits",
- "portable-atomic",
- "portable-atomic-util",
- "rawpointer",
-]
-
-[[package]]
-name = "ndarray"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7c9125e8f6f10c9da3aad044cc918cf8784fa34de857b1aa68038eb05a50a9"
@@ -370,12 +355,12 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa24ffc88cf9d43f7269d6b6a0d0a00010924a8cc90604a21ef9c433b66998d"
+checksum = "7aac2e6a6e4468ffa092ad43c39b81c79196c2bb773b8db4085f695efe3bba17"
 dependencies = [
  "libc",
- "ndarray 0.16.1",
+ "ndarray",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -459,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a6df7eab65fc7bee654a421404947e10a0f7085b6951bf2ea395f4659fb0cf"
+checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
 dependencies = [
  "indoc",
  "libc",
@@ -476,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f77d387774f6f6eec64a004eac0ed525aab7fa1966d94b42f743797b3e395afb"
+checksum = "b455933107de8642b4487ed26d912c2d899dec6114884214a0b3bb3be9261ea6"
 dependencies = [
  "python3-dll-a",
  "target-lexicon",
@@ -486,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dd13844a4242793e02df3e2ec093f540d948299a6a77ea9ce7afd8623f542be"
+checksum = "1c85c9cbfaddf651b1221594209aed57e9e5cff63c4d11d1feead529b872a089"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -496,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf8f9f1108270b90d3676b8679586385430e5c0bb78bb5f043f95499c821a71"
+checksum = "0a5b10c9bf9888125d917fb4d2ca2d25c8df94c7ab5a52e13313a07e050a3b02"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -508,9 +493,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a3b2274450ba5288bc9b8c1b69ff569d1d61189d4bff38f8d22e03d17f932b"
+checksum = "03b51720d314836e53327f5871d4c0cfb4fb37cc2c4a11cc71907a86342c40f9"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interpn"
-version = "0.8.2"
+version = "0.9.0"
 edition = "2024"
 authors = ["James Logan <jlogan03@gmail.com>"]
 license = "MIT OR Apache-2.0"
@@ -17,11 +17,11 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 # Rust lib deps
 num-traits = { version = "0.2.19", default-features = false, features = ["libm"] }
-crunchy = { version = "0.2.4", default-features = false, features = ["limit_256"] }
+crunchy = { version = "0.2.4", default-features = false }
 
 # Python bindings
-pyo3 = { version = "0.27.1", features = ["extension-module", "abi3-py310", "generate-import-lib"], optional = true }
-numpy = { version = "0.27.0", optional = true }
+pyo3 = { version = "0.27.2", features = ["extension-module", "abi3-py310", "generate-import-lib"], optional = true }
+numpy = { version = "0.27.1", optional = true }
 
 # Test-only utils
 itertools = { version = "0.14.0", optional = true }
@@ -32,9 +32,10 @@ criterion = "0.7.0"
 ndarray = "0.17.1"
 
 [features]
-default = ["std"]
+default = ["std", "crunchy/limit_64"]
 python = ["numpy", "pyo3", "std"]
 std = ["itertools"]
+deep-unroll = ["crunchy/limit_256"]
 fma = []
 
 [profile.release]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "interpn"
-version = "0.8.2"
+version = "0.9.0"
 description = "N-dimensional interpolation/extrapolation methods"
 authors = [{ name = "James Logan", email = "jlogan03@gmail.com" }]
 readme = "README.md"
@@ -69,7 +69,7 @@ no-build-package = [
 ]
 
 [tool.maturin]
-features = ["python", "fma"]
+features = ["python", "fma", "deep-unroll"]
 module-name = "interpn.interpn"
 python-packages = ["interpn"]
 python-source = "src"

--- a/src/multicubic/regular.rs
+++ b/src/multicubic/regular.rs
@@ -38,9 +38,9 @@ use num_traits::{Float, NumCast};
 /// Evaluate multicubic interpolation on a regular grid in up to 8 dimensions.
 /// Assumes C-style ordering of vals (z(x0, y0), z(x0, y1), ..., z(x0, yn), z(x1, y0), ...).
 ///
-/// For 1-4 dimensions, a fast flattened method is used. For higher dimensions, where that flattening
-/// becomes impractical due to compile times and instruction size, evaluation defers to a bounded
-/// recursion.
+/// For 1-4 dimensions with `deep-unroll` enabled (1-3 by default), a fast flattened method is used.
+/// For higher dimensions, where that flattening becomes impractical due to compile times and
+/// instruction size, evaluation defers to a bounded recursion.
 ///
 /// This is a convenience function; best performance will be achieved by using the exact right
 /// number for the N parameter, as this will slightly reduce compute and storage overhead,
@@ -87,14 +87,32 @@ pub fn interpn<T: Float>(
             linearize_extrapolation,
         )?
         .interp(obs.try_into().unwrap(), out),
-        4 => MulticubicRegular::<'_, T, 4>::new(
-            dims.try_into().unwrap(),
-            starts.try_into().unwrap(),
-            steps.try_into().unwrap(),
-            vals,
-            linearize_extrapolation,
-        )?
-        .interp(obs.try_into().unwrap(), out),
+        4 => {
+            // 4D cubic interpolation requires deep-unroll
+            #[cfg(not(feature = "deep-unroll"))]
+            {
+                MulticubicRegularRecursive::<'_, T, 4>::new(
+                    dims,
+                    starts,
+                    steps,
+                    vals,
+                    linearize_extrapolation,
+                )?
+                .interp(obs, out)
+            }
+
+            #[cfg(feature = "deep-unroll")]
+            {
+                MulticubicRegular::<'_, T, 4>::new(
+                    dims.try_into().unwrap(),
+                    starts.try_into().unwrap(),
+                    steps.try_into().unwrap(),
+                    vals,
+                    linearize_extrapolation,
+                )?
+                .interp(obs.try_into().unwrap(), out)
+            }
+        }
         5 => MulticubicRegularRecursive::<'_, T, 5>::new(
             dims,
             starts,
@@ -130,9 +148,7 @@ pub fn interpn<T: Float>(
         _ => Err(
             "Dimension exceeds maximum (8). Use interpolator struct directly for higher dimensions.",
         ),
-    }?;
-
-    Ok(())
+    }
 }
 
 /// Evaluate interpolant, allocating a new Vec for the output.
@@ -245,9 +261,15 @@ impl<'a, T: Float, const N: usize> MulticubicRegular<'a, T, N> {
     ) -> Result<Self, &'static str> {
         // Check dimensions
         const {
+            #[cfg(not(feature = "deep-unroll"))]
+            assert!(
+                N > 0 && N < 4,
+                "Flattened method defined for 1-3 dimensions by default (1-4 with `deep-unroll` feature). For higher dimensions, use recursive method."
+            );
+            #[cfg(feature = "deep-unroll")]
             assert!(
                 N > 0 && N < 5,
-                "Flattened method defined for 1-5 dimensions. For higher dimensions, use recursive method."
+                "Flattened method defined for 1-4 dimensions with `deep-unroll`. For higher dimensions, use recursive method."
             );
         }
         let nvals: usize = dims.iter().product();
@@ -365,10 +387,10 @@ impl<'a, T: Float, const N: usize> MulticubicRegular<'a, T, N> {
         const FP: usize = 4; // Footprint size      
         let nverts = const { FP.pow(N as u32) }; // Total number of vertices
 
-        unroll! {
-            for i < 256 in 0..nverts {  // const loop
+        macro_rules! unroll_vertices_body {
+            ($i:ident) => {
                 // Index, interpolate, or pass on each level of the tree
-                unroll!{
+                unroll! {
                     for j < 5 in 0..N {  // const loop
 
                         // Most of these iterations will get optimized out
@@ -380,19 +402,19 @@ impl<'a, T: Float, const N: usize> MulticubicRegular<'a, T, N> {
                                     // Bit pattern in an integer matches C-ordered array indexing
                                     // so we can just use the vertex index to index into the array
                                     // by selecting the appropriate bit from the index.
-                                    const OFFSET: usize = const{(i & (3 << (2*k))) >> (2*k)};
+                                    const OFFSET: usize = const{($i & (3 << (2*k))) >> (2*k)};
                                     loc[k] = origin[k] + OFFSET;
                                 }
                             }
-                            const STORE_IND: usize = i % FP;
+                            const STORE_IND: usize = $i % FP;
                             store[0][STORE_IND] = index_arr_fixed_dims(loc, dimprod, self.vals);
                         }
                         else { // const branch
                             // For other nodes, interpolate on child values
 
                             const Q: usize = const{FP.pow(j as u32)};
-                            const LEVEL: bool = const {(i + 1).is_multiple_of(Q)};
-                            const P: usize = const{((i + 1) / Q).saturating_sub(1) % FP};
+                            const LEVEL: bool = const {($i + 1).is_multiple_of(Q)};
+                            const P: usize = const{(($i + 1) / Q).saturating_sub(1) % FP};
                             const IND: usize = const{j.saturating_sub(1)};
 
                             if LEVEL { // const branch
@@ -408,6 +430,19 @@ impl<'a, T: Float, const N: usize> MulticubicRegular<'a, T, N> {
                         }
                     }
                 }
+            };
+        }
+
+        #[cfg(not(feature = "deep-unroll"))]
+        unroll! {
+            for i < 64 in 0..nverts {  // const loop
+                unroll_vertices_body!(i);
+            }
+        }
+        #[cfg(feature = "deep-unroll")]
+        unroll! {
+            for i < 256 in 0..nverts {  // const loop
+                unroll_vertices_body!(i);
             }
         }
 

--- a/uv.lock
+++ b/uv.lock
@@ -292,7 +292,7 @@ wheels = [
 
 [[package]]
 name = "interpn"
-version = "0.8.2"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION

## 0.9.0 2025-12-27

### Added

* Rust
  * Add `deep-unroll` feature that sets crunchy unroll depth to 256 and enables 4D unrolled cubic interpolation
    * This improves compile times in typical use-cases

### Changed

* Rust
  * Gate 4D unrolled cubic interpolation behind `deep-unroll` feature
  * Enable `deep-unroll` feature for Python builds
  * Update pyo3 deps